### PR TITLE
Enforce eventType values as specified in the api documentation.

### DIFF
--- a/src/model/claim.ts
+++ b/src/model/claim.ts
@@ -26,7 +26,7 @@ export class Claim {
   constructor(input: any, client: Seyna) {
     this[clientSym] = client;
 
-    this.portfolioId = input.product_id;
+    this.portfolioId = input.portfolio_id;
     this.contractId = input.contract_id;
     this.productId = input.product_id;
     this.id = input.id;

--- a/src/model/claim.ts
+++ b/src/model/claim.ts
@@ -9,7 +9,7 @@ export class Claim {
   productId: string;
   id: string;
   eventNum: number;
-  eventType: string;
+  eventType: "new" | "revaluation" | "payment" | "closed";
   eventDate: string;
   ref: string;
   debug?: string;

--- a/src/model/contract.ts
+++ b/src/model/contract.ts
@@ -118,7 +118,7 @@ export class Contract {
   productId: string;
 
   eventNum: number;
-  eventType: string;
+  eventType: "new" | "update" | "cancel";
   eventDate: string;
 
   ref: string;

--- a/src/model/receipt.ts
+++ b/src/model/receipt.ts
@@ -9,7 +9,7 @@ export class Receipt {
   productId: string;
   id: string;
   eventNum: number;
-  eventType: string;
+  eventType: "new" | "update" | "paid" | "overdue";
   eventDate: string;
   ref: string;
   debug?: string;

--- a/src/model/settlement.ts
+++ b/src/model/settlement.ts
@@ -10,7 +10,7 @@ export class Settlement {
   productId: string;
   id: string;
   eventNum: number;
-  eventType: string;
+  eventType: "new";
   eventDate: string;
   ref: string;
   debug?: string;


### PR DESCRIPTION
Update eventTypes:

- Contract: Update eventType type from string to `"new" | "update" | "cancel"`
- Receipt: Update eventType type from string to `"new" | "update" | "paid" | "overdue"`
- Claim: Update eventType type from string to `"new" | "revaluation" | "payment" | "closed"`
- Settlement: Update eventType type from string to `"new"`

Fix a mindo in the Claim constructor.