### PR TITLE
ContractGuarantees: Do not fromInput ContractGuarantee twice.

### DIFF
--- a/src/model/contract.ts
+++ b/src/model/contract.ts
@@ -13,7 +13,7 @@ export class ContractGuarantees {
   }
 
   addGuarantee(guarantee_name: string, guarantee_data: ContractGuarantee) {
-    this.data[guarantee_name] = ContractGuarantee.fromInput(guarantee_data);
+    this.data[guarantee_name] = guarantee_data;
   }
 
   sum(): ContractGuarantee {


### PR DESCRIPTION
`ReceiptGuarantees.addGuarantee` accepts a `ReceiptGuarantee` as its second argument.

No need for reapplying `ReceiptGuarantee.fromInput`twice, otherwise, it breaks the code due to the `.data` and creates an ill-formed `ReceiptGuarantee`

```js
ContractGuarantees {
  data: {
    data: ContractGuarantee {
      premium: undefined,
      tax: undefined,
      discount: undefined,
      broker_fee: undefined,
      cost_acquisition: undefined,
      cancel_premium: undefined
    }
  ```

Signed-off-by: Antony 'Dimrok' Méchin <antony.mechin@gmail.com>