### PR TITLE
ReceiptGuarantee: Add a negate method.

### DIFF
--- a/src/model/receipt.ts
+++ b/src/model/receipt.ts
@@ -98,4 +98,13 @@ export class ReceiptGuarantee {
     result.cost_acquisition = this.cost_acquisition + value.cost_acquisition;
     return result;
   }
+  negate(): ReceiptGuarantee {
+    let result = new ReceiptGuarantee();
+    result.premium = -this.premium;
+    result.tax = -this.tax;
+    result.discount = -this.discount;
+    result.broker_fee = -this.broker_fee;
+    result.cost_acquisition = -this.cost_acquisition;
+    return result;
+  }
 }


### PR DESCRIPTION
`.negate` allows one to easily negate a receipt (e.g. for cancellation purpose).

Signed-off-by: Antony 'Dimrok' Méchin <antony.mechin@gmail.com>